### PR TITLE
Added extra XBox button, don't add unknown controllers, removed unsed…

### DIFF
--- a/lib/Gamepad.js
+++ b/lib/Gamepad.js
@@ -51,7 +51,9 @@ var Gamepad = function (_React$Component) {
         DPadUp: false,
         DPadRight: false,
         DPadDown: false,
-        DPadLeft: false
+        DPadLeft: false,
+
+        ExtraButton: false
       },
 
       axis: {
@@ -86,7 +88,7 @@ var Gamepad = function (_React$Component) {
       if (!this.mounted) return;
 
       var gamepadIndex = this.props.gamepadIndex;
-      var gamepads = navigator.getGamepads();
+      var gamepads = this.getGamepads(navigator.getGamepads());
 
       if (gamepads.length && gamepads.length > gamepadIndex && gamepads[gamepadIndex]) {
         var gamepad = gamepads[gamepadIndex];
@@ -137,8 +139,6 @@ var Gamepad = function (_React$Component) {
     value: function updateAllAxis(gamepad) {
       for (var i = 0; i < gamepad.axes.length; ++i) {
         var axisName = this.axisIndexToAxisName(i);
-        var value = gamepad.axes[i];
-
         this.updateAxis(axisName, gamepad.axes[i]);
       }
     }
@@ -220,6 +220,20 @@ var Gamepad = function (_React$Component) {
       return null;
     }
   }, {
+    key: 'getGamepads',
+    value: function getGamepads(peripherals) {
+      var gamepads = [];
+      for (var i = 0; i < peripherals.length; i++) {
+        if (peripherals[i]) {
+          var controllerId = peripherals[i]['id'];
+          if (controllerId.indexOf('Unknown Gamepad') === -1) {
+            gamepads.push(peripherals[i]);
+          }
+        }
+      }
+      return gamepads;
+    }
+  }, {
     key: 'render',
     value: function render() {
       return _react2.default.Children.only(this.props.children);
@@ -266,5 +280,6 @@ Gamepad.defaultProps = {
   onDown: function onDown() {},
   onLeft: function onLeft() {},
   onRight: function onRight() {}
+
 };
 exports.default = Gamepad;

--- a/lib/layouts/XBOX.js
+++ b/lib/layouts/XBOX.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = {
-  buttons: ['A', 'B', 'X', 'Y', 'LB', 'RB', 'LT', 'RT', 'Back', 'Start', 'LS', 'RS', 'DPadUp', 'DPadDown', 'DPadLeft', 'DPadRight'],
+  buttons: ['A', 'B', 'X', 'Y', 'LB', 'RB', 'LT', 'RT', 'Back', 'Start', 'LS', 'RS', 'DPadUp', 'DPadDown', 'DPadLeft', 'DPadRight', 'ExtraButton'],
   axis: ['LeftStickX', '-LeftStickY', 'RightStickX', '-RightStickY'],
   buttonAxis: [null, null, null, null, null, null, 'LeftTrigger', 'RightTrigger']
 };

--- a/src/Gamepad.js
+++ b/src/Gamepad.js
@@ -40,6 +40,7 @@ class Gamepad extends React.Component {
     onDown: () => {},
     onLeft: () => {},
     onRight: () => {},
+    
   }
 
   constructor(props, context) {
@@ -69,6 +70,8 @@ class Gamepad extends React.Component {
         DPadRight: false,
         DPadDown: false,
         DPadLeft: false,
+
+        ExtraButton: false,
       },
 
       axis: {
@@ -98,8 +101,8 @@ class Gamepad extends React.Component {
     if (!this.mounted) return
 
     const gamepadIndex = this.props.gamepadIndex
-    const gamepads = navigator.getGamepads()
-
+    const gamepads = this.getGamepads(navigator.getGamepads())
+    
     if (gamepads.length && gamepads.length > gamepadIndex && gamepads[gamepadIndex]) {
       const gamepad = gamepads[gamepadIndex]
 
@@ -147,8 +150,6 @@ class Gamepad extends React.Component {
   updateAllAxis(gamepad) {
     for (let i = 0; i < gamepad.axes.length; ++i) {
       let axisName = this.axisIndexToAxisName(i)
-      const value = gamepad.axes[i]
-
       this.updateAxis(axisName, gamepad.axes[i])
     }
   }
@@ -231,6 +232,19 @@ class Gamepad extends React.Component {
     }
 
     return null
+  }
+
+  getGamepads(peripherals) {
+    const gamepads = []
+    for(let i = 0; i < peripherals.length; i++) {
+      if(peripherals[i]){
+        const controllerId = peripherals[i]['id']
+        if(controllerId.indexOf('Unknown Gamepad') === -1) {
+          gamepads.push(peripherals[i])
+        }
+      }
+    }
+    return gamepads
   }
 
   render() {

--- a/src/layouts/XBOX.js
+++ b/src/layouts/XBOX.js
@@ -16,6 +16,7 @@ export default {
     'DPadDown',
     'DPadLeft',
     'DPadRight',
+    'ExtraButton'
   ],
   axis: [
     'LeftStickX',


### PR DESCRIPTION
… var

Fix issue 3[https://github.com/SBRK/react-gamepad/issues/3] the error part regarding the console log error for the unknown button.

The source has 16 buttons, the XBox Controller object has 17 buttons when inspecting the gamepad object.

Testing with an XBox One controller so this could be different to an XBox 360 controller.

I have also added some code to ensure we don't add any Unknown Controllers as we currently only support XBox.

Thanks.
