### PR TITLE
Return without console error if button is not defined

### DIFF
--- a/lib/Gamepad.js
+++ b/lib/Gamepad.js
@@ -123,8 +123,9 @@ var Gamepad = function (_React$Component) {
     key: 'updateButton',
     value: function updateButton(buttonName, pressed) {
       if (this.padState.buttons[buttonName] === undefined) {
-        console.error('Unknown button ' + buttonName);
-      } else if (this.padState.buttons[buttonName] !== pressed) {
+        return;
+      }
+      if (this.padState.buttons[buttonName] !== pressed) {
         this.padState.buttons[buttonName] = pressed;
 
         this.props.onButtonChange(buttonName, pressed);

--- a/src/Gamepad.js
+++ b/src/Gamepad.js
@@ -133,8 +133,9 @@ class Gamepad extends React.Component {
 
   updateButton(buttonName, pressed) {
     if (this.padState.buttons[buttonName] === undefined) {
-      console.error(`Unknown button ${buttonName}`)
-    } else if (this.padState.buttons[buttonName] !== pressed) {
+      return
+    } 
+    if (this.padState.buttons[buttonName] !== pressed) {
       this.padState.buttons[buttonName] = pressed
 
       this.props.onButtonChange(buttonName, pressed)


### PR DESCRIPTION
`navigator.getGamePads()` returns an XBox controller with 17 buttons.

The current code supports a controller with 16 buttons objects, the most efficient way to resolve the console error logs is to return without throwing them. It maybe that XBox 360 controller returns 16 buttons and the XBox One controller returns 17 buttons objects. At present I don't not know what the additional XBox One button object is, until we do and we know what it is we can ignore it.